### PR TITLE
Fix incompatibility with Chef 13

### DIFF
--- a/providers/userdefaults.rb
+++ b/providers/userdefaults.rb
@@ -22,7 +22,7 @@ require 'chef/mixin/language'
 include Chef::Mixin::ShellOut
 
 def load_current_resource
-  @userdefaults = Chef::Resource::MacOsXUserdefaults.new(new_resource.name)
+  @userdefaults = Chef::Resource.resource_for_node(:mac_os_x_userdefaults, node).new(new_resource.name)
   @userdefaults.key(new_resource.key)
   @userdefaults.domain(new_resource.domain)
   Chef::Log.debug("Checking #{new_resource.domain} value")


### PR DESCRIPTION
Per the Chef 13 [release notes](https://docs.chef.io/release_notes.html)
LWRP resources no longer get constant names, resulting in this:

```
[2017-04-17T11:50:32-07:00] ERROR: mac_os_x_userdefaults[com.apple.dock autohide] (my-dev-machine::default line 120) had an error: NameError: uninitialized constant Chef::Resource::MacOsXUserdefaults
Did you mean?  Chef::Resource::MacosxService
Did you mean?  Chef::Resource::MacosxService
[2017-04-17T11:50:32-07:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

Signed-off-by: Jonathan Hartman <j@p4nt5.com>